### PR TITLE
Add Working Directory Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ For the `DistributionTool` to find the inputted directory path, the environment 
 
 Usage
 -----
+## Simple Example
+
+### Folder Structure:
+```
+.github
+  - workflows
+    - your_workflow.yml
+com.company.plugin_name.sdPlugin
+  - <your plugin files>
+release
+```
+
+### Workflow Step:
 ```
 - name: StreamDeck Distribution Tool
   uses: AdamCarballo/streamdeck-distribution-tool@v1
@@ -17,6 +30,30 @@ Usage
     working-directory: .
 ```
 This example will take the contents of the `com.company.plugin_name.sdPlugin` folder and export the plugin into the `release` directory.
+
+## Complex Example
+
+### Folder Structure:
+```
+.github
+  - workflows
+    - your_workflow.yml
+plugin
+  - com.company.plugin_name.sdPlugin
+    - <your plugin files>
+release
+```
+
+### Workflow Step:
+```
+- name: StreamDeck Distribution Tool
+  uses: AdamCarballo/streamdeck-distribution-tool@v1
+  with:
+    input: com.company.plugin_name.sdPlugin
+    output: ../release
+    working-directory: plugin
+```
+This example shows how to use the `working-directory` input when the plugin source files are not in the root of the repository. In addition, the `output` directory is set to `../release` to export the plugin into the `release` directory, to show how to use relative paths, including parent directories.
 
 The `DistributionTool` requires both directories to exist (*it can't create directories*) and it must be run in a Windows or MacOS machine. **Linux (*`ubuntu-latest`, etc.*) is not supported**.
 
@@ -29,7 +66,7 @@ Source files directory path.<br>
 - **Required**: Yes
 
 #### `output`
-Exported plugin directory path. Takes into account the value of `$GITHUB_WORKSPACE` and `working-directory`.
+Exported plugin directory path. Use relative paths from the directory `$GITHUB_WORKSPACE`/`working-directory`. If omitted, the action will default to outputting the plugin file in the same directory as the source folder.
 
 - **Required**: No
 - **Default**: / *(`$GITHUB_WORKSPACE`/`working-directory`)*

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Source files directory path.<br>
 Exported plugin directory path. Use relative paths from the directory `$GITHUB_WORKSPACE`/`working-directory`. If omitted, the action will default to outputting the plugin file in the same directory as the source folder.
 
 - **Required**: No
-- **Default**: / *(`$GITHUB_WORKSPACE`/`working-directory`)*
+- **Default**: . *(`$GITHUB_WORKSPACE`/`working-directory`)*
 
 #### `working-directory`
 Working directory path. Relative to the value of `$GITHUB_WORKSPACE`. If not set, the action will assume the `.sdPlugin` folder is in the root of the repository.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ release
   with:
     input: com.company.plugin_name.sdPlugin
     output: release
-    working-directory: .
 ```
 This example will take the contents of the `com.company.plugin_name.sdPlugin` folder and export the plugin into the `release` directory.
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Source files directory path.<br>
 - **Required**: Yes
 
 #### `output`
-Exported plugin directory path.
+Exported plugin directory path. Takes into account the value of `$GITHUB_WORKSPACE` and `working-directory`.
 
 - **Required**: No
-- **Default**: / *(`$GITHUB_WORKSPACE`)*
+- **Default**: / *(`$GITHUB_WORKSPACE`/`working-directory`)*
 
 #### `working-directory`
 Working directory path. Relative to the value of `$GITHUB_WORKSPACE`. If not set, the action will assume the `.sdPlugin` folder is in the root of the repository.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Usage
   with:
     input: com.company.plugin_name.sdPlugin
     output: release
+    working-directory: .
 ```
 This example will take the contents of the `com.company.plugin_name.sdPlugin` folder and export the plugin into the `release` directory.
 
@@ -32,6 +33,12 @@ Exported plugin directory path.
 
 - **Required**: No
 - **Default**: / *(`$GITHUB_WORKSPACE`)*
+
+#### `working-directory`
+Working directory path. Relative to the value of `$GITHUB_WORKSPACE`. If not set, the action will assume the `.sdPlugin` folder is in the root of the repository.
+
+- **Required**: No
+- **Default**: . *(No effect)*
 
 Legal
 ------

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   output:
     description: 'Exported plugin directory path'
     required: false
-    default: '/'
+    default: '.'
   working-directory:
     description: 'Directory .sdPlugin directory is in, relative to GITHUB_WORKSPACE'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,12 @@ inputs:
     description: 'Exported plugin directory path'
     required: false
     default: '/'
+  working-directory:
+    description: 'Directory .sdPlugin directory is in, relative to GITHUB_WORKSPACE'
+    required: false
+    default: '.'
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/main.sh ${{ inputs.input }} ${{ inputs.output }} ${{ runner.os }}
+    - run: $GITHUB_ACTION_PATH/main.sh ${{ inputs.input }} ${{ inputs.output }} ${{ runner.os }} ${{ inputs.working-directory }}
       shell: bash

--- a/main.sh
+++ b/main.sh
@@ -7,10 +7,12 @@
 
 if [[ $3 == "Windows" ]]
 then
-	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$GITHUB_WORKSPACE\\$4\\$1" -o "$GITHUB_WORKSPACE\\$4\\$2"
+	cd $GITHUB_WORKSPACE\\$4
+	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$1" -o "$2"
 elif [[ $3 == "macOS" ]]
 then
-   	$GITHUB_ACTION_PATH/./DistributionTool -b -i "$GITHUB_WORKSPACE/$4/$1" -o "$GITHUB_WORKSPACE/$4/$2"
+	cd $GITHUB_WORKSPACE/$4
+   	$GITHUB_ACTION_PATH/./DistributionTool -b -i "$1" -o "$2"
 else
   	echo "StreamDeck Distribution Tool only has binaries for Windows or MacOS."
   	exit 1

--- a/main.sh
+++ b/main.sh
@@ -9,6 +9,7 @@ if [[ $3 == "Windows" ]]
 then
 	cd $GITHUB_WORKSPACE\\$4
 	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$1" -o "$2"
+	echo "$(PWD)"
 elif [[ $3 == "macOS" ]]
 then
 	cd $GITHUB_WORKSPACE/$4

--- a/main.sh
+++ b/main.sh
@@ -3,13 +3,14 @@
 # $1 = input path
 # $2 = output path
 # $3 = runtime OS
+# $4 = working directory
 
 if [[ $3 == "Windows" ]]
 then
-	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$GITHUB_WORKSPACE\\$1" -o "$GITHUB_WORKSPACE\\$2"
+	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$GITHUB_WORKSPACE\\$4\\$1" -o "$GITHUB_WORKSPACE\\$4\\$2"
 elif [[ $3 == "macOS" ]]
 then
-   	$GITHUB_ACTION_PATH/./DistributionTool -b -i "$GITHUB_WORKSPACE/$1" -o "$GITHUB_WORKSPACE/$2"
+   	$GITHUB_ACTION_PATH/./DistributionTool -b -i "$GITHUB_WORKSPACE/$4/$1" -o "$GITHUB_WORKSPACE/$4/$2"
 else
   	echo "StreamDeck Distribution Tool only has binaries for Windows or MacOS."
   	exit 1

--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,6 @@ if [[ $3 == "Windows" ]]
 then
 	cd $GITHUB_WORKSPACE\\$4
 	$GITHUB_ACTION_PATH/DistributionTool.exe -b -i "$1" -o "$2"
-	echo "$(PWD)"
 elif [[ $3 == "macOS" ]]
 then
 	cd $GITHUB_WORKSPACE/$4


### PR DESCRIPTION
Adds support for the plugin source folder to not be in the root of the repository using a new input `working-directory`.

For example, let's say the repository looks like this:
```
<normal repo stuff>
Plugin
    - com.example.plugin.sdPlugin
        - <plugin source files>
```

In the current release (v1.0.1) attempting to use the input "Plugin/com.example.plugin.sdPlugin" fails because the plugin name is invalid due to the `P` (DistributionTool does not allow uppercase letters in the plugin name, and at this point the whole input is used, not just the name of the `.sdPlugin` folder itself)

To fix this I added a working-directory input and modified the shell script so we change directory to GITHUB_WORKSPACE and then working-directory inside of that. This means that we only pass the true name of the plugin, instead of the whole path.

To use the example above, the new inputs would be:

```
with:
  input: com.example.plugin.sdPlugin
  working-directory: Plugin
```
(output was omitted, by default now outputs plugin file to same directory the plugin source folder is in. In the example above the plugin file will be found in the Plugin folder)

I've also updated the README with an example as well.

In terms of backwards compatibility: Should work perfectly, all defaults should act as they did before. And not specifying the working-directory input will not break existing configs.